### PR TITLE
Добавление strip() в определение модифицированных файлов

### DIFF
--- a/src/undiff1c/undiff1c.py
+++ b/src/undiff1c/undiff1c.py
@@ -67,7 +67,7 @@ def get_list_of_comitted_files():
     for result in output.split('\n'):
         log.info(result)
         if result != '':
-            match = modified.match(result)
+            match = modified.match(result.strip())
             if match:
                 files.append(match.group('name'))
 


### PR DESCRIPTION
На моем конфиге (windows x64, git 2.5.1) потребовалось добавление strip к строке поиска, чтобы отработала регулярка из modified - в строке, которую выдает "git status --porcelain" в начале строки есть пробельный символ.
