### PR TITLE
После удаления из индекса файла сбросим его изменения

### DIFF
--- a/undiff1c/undiff1c.py
+++ b/undiff1c/undiff1c.py
@@ -142,7 +142,7 @@ def replace_old_form_attr(filelists):
     
 def git_reset_file(file, sha):
     output = subprocess.check_output(['git', 'reset', sha, file]).decode('utf-8')
-
+    output = subprocess.check_output(['git', 'checkout', file]).decode('utf-8')
 
 def main():
     parser = argparse.ArgumentParser(description='Утилита для проверки ошибочно изменных файлов в индексе')


### PR DESCRIPTION
Для того, чтобы в каталоге исходников не оставалось untracked modified файлов после удаления из индекса откатываем и сам файл.
